### PR TITLE
Bump to primitive-type 0.12.1 to unblock ethers-rs CI issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,9 +95,9 @@ dependencies = [
 
 [[package]]
 name = "fixed-hash"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcf0ed7fe52a17a03854ec54a9f76d6d84508d1c0e66bc1793301c73fc8493c"
+checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
 dependencies = [
  "static_assertions",
 ]
@@ -186,9 +186,9 @@ checksum = "d1a3ea4f0dd7f1f3e512cf97bf100819aa547f36a6eccac8dbaae839eb92363e"
 
 [[package]]
 name = "primitive-types"
-version = "0.11.1"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e28720988bff275df1f51b171e1b2a18c30d194c4d2b61defdacecd625a5d94a"
+checksum = "9f3486ccba82358b11a77516035647c34ba167dfa53312630de83b12bd4f3d66"
 dependencies = [
  "fixed-hash",
  "uint",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,7 +301,7 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "trezor-client"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "bitcoin",
  "bitcoin-bech32",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ bitcoin-bech32 = { version = "0.9.0", optional = true }
 secp256k1 = { version = "0.12.0", optional = true }
 
 # ethereum
-primitive-types = { version = "0.11.1", default-features = false, optional = true }
+primitive-types = { version = "0.12.1", default-features = false, optional = true }
 
 protobuf = "2.0"
 byteorder = "1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trezor-client"
-version = "0.0.6"
+version = "0.0.7"
 authors = ["joshie", "romanz", "Steven Roose <steven@stevenroose.org>"]
 license = "CC0-1.0"
 homepage = "https://github.com/joshieDo/rust-trezor-api"


### PR DESCRIPTION
~Would you also please cut a new release ethers-rs can move to. Thanks!~

Edit: I reviewed the previous v0.0.6 release and it just looked like the revision number needed to be bumped so have included it here as well.