### PR TITLE
fix model names

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,17 +62,17 @@ use std::fmt;
 /// The different kind of Trezor device models.
 #[derive(PartialEq, Eq, Clone, Debug, Copy)]
 pub enum Model {
-	Trezor1,
-	Trezor2,
-	Trezor2Bl,
+	TrezorLegacy,
+	Trezor,
+	TrezorBootloader,
 }
 
 impl fmt::Display for Model {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		f.write_str(match self {
-			Model::Trezor1 => "Trezor 1",
-			Model::Trezor2 => "Trezor 2",
-			Model::Trezor2Bl => "Trezor 2 Bootloader",
+			Model::TrezorLegacy => "Trezor (legacy)",
+			Model::Trezor => "Trezor",
+			Model::TrezorBootloader => "Trezor (bootloader)",
 		})
 	}
 }

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -72,17 +72,17 @@ pub fn connect(available_device: &AvailableDevice) -> Result<Box<dyn Transport>,
 mod constants {
 	//! A collection of transport-global constants.
 
-	pub const DEV_TREZOR1: (u16, u16) = (0x534C, 0x0001);
-	pub const DEV_TREZOR2: (u16, u16) = (0x1209, 0x53C1);
-	pub const DEV_TREZOR2_BL: (u16, u16) = (0x1209, 0x53C0);
+	pub const DEV_TREZOR_LEGACY: (u16, u16) = (0x534C, 0x0001);
+	pub const DEV_TREZOR: (u16, u16) = (0x1209, 0x53C1);
+	pub const DEV_TREZOR_BOOTLOADER: (u16, u16) = (0x1209, 0x53C0);
 }
 
 /// Derive the Trezor model from the HID device.
 pub(crate) fn derive_model(dev_id: (u16, u16)) -> Option<Model> {
 	match dev_id {
-		constants::DEV_TREZOR1 => Some(Model::Trezor1),
-		constants::DEV_TREZOR2 => Some(Model::Trezor2),
-		constants::DEV_TREZOR2_BL => Some(Model::Trezor2Bl),
+		constants::DEV_TREZOR_LEGACY => Some(Model::TrezorLegacy),
+		constants::DEV_TREZOR => Some(Model::Trezor),
+		constants::DEV_TREZOR_BOOTLOADER => Some(Model::TrezorBootloader),
 		_ => None,
 	}
 }


### PR DESCRIPTION
The USB vendorID/productID does not imply Trezor Model.

We only used `0x534C/0x0001` for early devices manufactured before 2018. Most of the devices in circulation use `0x1209/0x53C1` when in normal mode and `0x1209/0x53C0` when in the bootloader.

I think the proposed change makes this more clear.