### PR TITLE
Add UDP transport for Trezor Emulator

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,6 +65,7 @@ pub enum Model {
 	Trezor1,
 	Trezor2,
 	Trezor2Bl,
+	TrezorEmulator,
 }
 
 impl fmt::Display for Model {
@@ -73,6 +74,7 @@ impl fmt::Display for Model {
 			Model::Trezor1 => "Trezor 1",
 			Model::Trezor2 => "Trezor 2",
 			Model::Trezor2Bl => "Trezor 2 Bootloader",
+			Model::TrezorEmulator => "Trezor Emulator",
 		})
 	}
 }
@@ -107,8 +109,10 @@ impl AvailableDevice {
 /// To use those, please use [find_hid_device].
 pub fn find_devices(debug: bool) -> Result<Vec<AvailableDevice>> {
 	let mut devices = Vec::new();
+	use transport::udp::UdpTransport;
 	use transport::webusb::WebUsbTransport;
 	devices.extend(WebUsbTransport::find_devices(debug).map_err(Error::TransportConnect)?);
+	devices.extend(UdpTransport::find_devices(debug, None).map_err(Error::TransportConnect)?);
 	Ok(devices)
 }
 

--- a/src/transport/error.rs
+++ b/src/transport/error.rs
@@ -13,6 +13,8 @@ pub enum Error {
 	Hid(hid::HidError),
 	/// Error from ruusb.
 	Usb(rusb::Error),
+	/// Error from io
+	IO(std::io::Error),
 	/// The device to connect to was not found.
 	DeviceNotFound,
 	/// The device is no longer available.
@@ -47,6 +49,12 @@ impl From<rusb::Error> for Error {
 	}
 }
 
+impl From<std::io::Error> for Error {
+	fn from(e: std::io::Error) -> Error {
+		Error::IO(e)
+	}
+}
+
 impl error::Error for Error {
 	fn cause(&self) -> Option<&dyn error::Error> {
 		match *self {
@@ -62,6 +70,7 @@ impl fmt::Display for Error {
 		match *self {
 			Error::Hid(ref e) => fmt::Display::fmt(e, f),
 			Error::Usb(ref e) => fmt::Display::fmt(e, f),
+			Error::IO(ref e) => fmt::Display::fmt(e, f),
 			Error::DeviceNotFound => write!(f, "the device to connect to was not found"),
 			Error::DeviceDisconnected => write!(f, "the device is no longer available"),
 			Error::UnknownHidVersion => write!(f, "HID version of the device unknown"),

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -7,6 +7,7 @@ use protos::MessageType;
 pub mod error;
 pub mod hid;
 pub mod protocol;
+pub mod udp;
 pub mod webusb;
 
 /// An available transport for a Trezor device, containing any of the different supported
@@ -15,6 +16,7 @@ pub mod webusb;
 pub enum AvailableDeviceTransport {
 	Hid(hid::AvailableHidTransport),
 	WebUsb(webusb::AvailableWebUsbTransport),
+	Udp(udp::AvailableUdpTransport),
 }
 
 impl fmt::Display for AvailableDeviceTransport {
@@ -22,6 +24,7 @@ impl fmt::Display for AvailableDeviceTransport {
 		match self {
 			AvailableDeviceTransport::Hid(ref t) => write!(f, "{}", t),
 			AvailableDeviceTransport::WebUsb(ref t) => write!(f, "{}", t),
+			AvailableDeviceTransport::Udp(ref t) => write!(f, "{}", t),
 		}
 	}
 }
@@ -66,6 +69,7 @@ pub fn connect(available_device: &AvailableDevice) -> Result<Box<dyn Transport>,
 	match available_device.transport {
 		AvailableDeviceTransport::Hid(_) => hid::HidTransport::connect(available_device),
 		AvailableDeviceTransport::WebUsb(_) => webusb::WebUsbTransport::connect(available_device),
+		AvailableDeviceTransport::Udp(_) => udp::UdpTransport::connect(available_device),
 	}
 }
 

--- a/src/transport/udp.rs
+++ b/src/transport/udp.rs
@@ -1,0 +1,161 @@
+use std::net::UdpSocket;
+use std::time::Duration;
+use std::{fmt, result::Result};
+use transport::error::Error;
+
+use crate::{AvailableDevice, Model};
+
+use self::constants::{DEFAULT_DEBUG_PORT, DEFAULT_HOST, DEFAULT_PORT, LOCAL_LISTENER};
+
+use super::{AvailableDeviceTransport, ProtoMessage, Transport};
+use transport::protocol::{Link, Protocol, ProtocolV1};
+
+mod constants {
+	///! A collection of constants related to the Emulator Ports.
+	pub const DEFAULT_HOST: &str = "127.0.0.1";
+	pub const DEFAULT_PORT: &str = "21324";
+	pub const DEFAULT_DEBUG_PORT: &str = "21325";
+	pub const LOCAL_LISTENER: &str = "127.0.0.1:34254";
+}
+/// The chunk size for the serial protocol.
+const CHUNK_SIZE: usize = 64;
+
+const READ_TIMEOUT_MS: u64 = 100000;
+const WRITE_TIMEOUT_MS: u64 = 100000;
+
+/// An available transport for connecting with a device.
+#[derive(Debug)]
+pub struct AvailableUdpTransport {
+	pub host: String,
+	pub port: String,
+}
+
+impl fmt::Display for AvailableUdpTransport {
+	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+		write!(f, "udp:{}:{}", self.host, self.port)
+	}
+}
+
+/// An actual serial HID USB link to a device over which bytes can be sent.
+struct UdpLink {
+	pub socket: UdpSocket,
+	pub device: (String, String),
+}
+// No need to implement drop as every member is owned
+
+impl Link for UdpLink {
+	fn write_chunk(&mut self, chunk: Vec<u8>) -> Result<(), Error> {
+		debug_assert_eq!(CHUNK_SIZE, chunk.len());
+		let timeout = Duration::from_millis(WRITE_TIMEOUT_MS);
+		self.socket.set_write_timeout(Some(timeout))?;
+		if let Err(e) = self.socket.send(&chunk) {
+			return Err(e.into());
+		}
+		Ok(())
+	}
+
+	fn read_chunk(&mut self) -> Result<Vec<u8>, Error> {
+		let mut chunk = vec![0; CHUNK_SIZE];
+		let timeout = Duration::from_millis(READ_TIMEOUT_MS);
+		self.socket.set_read_timeout(Some(timeout))?;
+
+		let n = self.socket.recv(&mut chunk)?;
+		if n == CHUNK_SIZE {
+			Ok(chunk)
+		} else {
+			Err(Error::DeviceReadTimeout)
+		}
+	}
+}
+
+impl UdpLink {
+	pub fn open(path: &str) -> Result<UdpLink, Error> {
+		let mut parts = path.split(':');
+		let link = Self {
+			socket: UdpSocket::bind(LOCAL_LISTENER)?,
+			device: (
+				parts.next().expect("Incorrect Path").to_owned(),
+				parts.next().expect("Incorrect Path").to_owned(),
+			),
+		};
+		link.socket.connect(path)?;
+		Ok(link)
+	}
+	// Ping the port and compare against expected response
+	fn ping(&self) -> Result<bool, Error> {
+		let mut resp = vec![0; CHUNK_SIZE];
+		self.socket.send("PINGPING".as_bytes())?;
+		let size = self.socket.recv(&mut resp)?;
+		Ok(&resp[..size] == "PONGPONG".as_bytes())
+	}
+}
+
+/// An implementation of the Transport interface for UDP devices.
+pub struct UdpTransport {
+	protocol: ProtocolV1<UdpLink>,
+}
+
+impl UdpTransport {
+	pub fn find_devices(debug: bool, path: Option<&str>) -> Result<Vec<AvailableDevice>, Error> {
+		let mut devices = Vec::new();
+		let mut dest = String::new();
+		match path {
+			Some(p) => dest = p.to_owned(),
+			None => {
+				dest.push_str(DEFAULT_HOST);
+				dest.push(':');
+				dest.push_str(if debug {
+					DEFAULT_DEBUG_PORT
+				} else {
+					DEFAULT_PORT
+				});
+			}
+		};
+		let link = UdpLink::open(&dest)?;
+		if link.ping()? {
+			devices.push(AvailableDevice {
+				model: Model::TrezorEmulator,
+				debug,
+				transport: AvailableDeviceTransport::Udp(AvailableUdpTransport {
+					host: link.device.0,
+					port: link.device.1,
+				}),
+			});
+		}
+		Ok(devices)
+	}
+
+	/// Connect to a device over the UDP transport.
+	pub fn connect(device: &AvailableDevice) -> Result<Box<dyn Transport>, Error> {
+		let transport = match device.transport {
+			AvailableDeviceTransport::Udp(ref t) => t,
+			_ => panic!("passed wrong AvailableDevice in UdpTransport::connect"),
+		};
+		let mut path = String::new();
+		path.push_str(&transport.host);
+		path.push(':');
+		path.push_str(&transport.port);
+		let link = UdpLink::open(&path)?;
+		Ok(Box::new(UdpTransport {
+			protocol: ProtocolV1 {
+				link,
+			},
+		}))
+	}
+}
+
+impl super::Transport for UdpTransport {
+	fn session_begin(&mut self) -> Result<(), Error> {
+		self.protocol.session_begin()
+	}
+	fn session_end(&mut self) -> Result<(), Error> {
+		self.protocol.session_end()
+	}
+
+	fn write_message(&mut self, message: ProtoMessage) -> Result<(), Error> {
+		self.protocol.write(message)
+	}
+	fn read_message(&mut self) -> Result<ProtoMessage, Error> {
+		self.protocol.read()
+	}
+}


### PR DESCRIPTION
This PR adds rudimentary support for Trezor Emulator. Now the Emulator is discovered and its features are listed.